### PR TITLE
Fix image deletion logic to use public disk storage in EventController

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -140,7 +140,7 @@ class EventController extends Controller
             $data = $request->validated();
             if ($request->hasFile('img_path')) {
                 // Delete old image if it exists
-                if ($event->img_path && Storage::exists($event->img_path)) {
+                if ($event->img_path && Storage::disk('public')->exists($event->img_path)) {
                     Storage::delete($event->img_path);
                 }
                 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix image deletion logic to use public disk storage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event Update Request"] --> B["Check Old Image Exists"]
  B --> C["Delete from Public Disk"]
  C --> D["Store New Image"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EventController.php</strong><dd><code>Fix storage disk specification for image deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Http/Controllers/EventController.php

<ul><li>Modified image existence check to use <code>Storage::disk('public')</code> instead <br>of default storage</ul>


</details>


  </td>
  <td><a href="https://github.com/MznAarik/final_project/pull/73/files#diff-e9e47c7018c1905fd246eae03c806f9201694932ce9a583c41431dc8896bcbdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

