### PR TITLE
Fix image deletion logic to use public disk storage in update method

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -141,7 +141,7 @@ class EventController extends Controller
             if ($request->hasFile('img_path')) {
                 // Delete old image if it exists
                 if ($event->img_path && Storage::disk('public')->exists($event->img_path)) {
-                    Storage::delete($event->img_path);
+                    Storage::disk('public')->delete($event->img_path);
                 }
                 
                 // Store new image


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix image deletion to use correct disk storage

- Ensure consistency with public disk configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Image Check"] --> B["Delete from Default Disk"]
  A --> C["Delete from Public Disk"]
  B -.-> D["Inconsistent Storage"]
  C --> E["Consistent Storage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EventController.php</strong><dd><code>Fix storage disk consistency for image deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Http/Controllers/EventController.php

<ul><li>Changed <code>Storage::delete()</code> to <code>Storage::disk('public')->delete()</code><br> <li> Fixed inconsistency in disk storage usage for image deletion</ul>


</details>


  </td>
  <td><a href="https://github.com/MznAarik/final_project/pull/74/files#diff-e9e47c7018c1905fd246eae03c806f9201694932ce9a583c41431dc8896bcbdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

